### PR TITLE
Disable "Blob storage website CI" action on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,6 @@ name: Blob storage website CI
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
     
 jobs:
   build:


### PR DESCRIPTION
- action requires credentials which are not passed to PRs